### PR TITLE
Disable package publishing in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
 
-      - name: Publish package
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-        run: |
-          twine upload dist/*
+#      - name: Publish package
+#        env:
+#          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#        run: |
+#          twine upload dist/*


### PR DESCRIPTION
Commented out the steps responsible for publishing the package to PyPI. This change is meant to temporarily halt automatic uploads while we address issues with the release process.